### PR TITLE
Add option to disable item count overlay

### DIFF
--- a/src/main/java/dev/zanckor/advancedinventory/AdvancedInventory.java
+++ b/src/main/java/dev/zanckor/advancedinventory/AdvancedInventory.java
@@ -3,6 +3,7 @@ package dev.zanckor.advancedinventory;
 import com.mojang.logging.LogUtils;
 import dev.zanckor.advancedinventory.common.network.NetworkHandler;
 import dev.zanckor.advancedinventory.core.config.ServerConfig;
+import dev.zanckor.advancedinventory.core.config.ClientConfig;
 import dev.zanckor.advancedinventory.core.registry.ItemRegistry;
 import dev.zanckor.advancedinventory.core.registry.LootModifierRegistry;
 import net.minecraft.client.renderer.item.ItemProperties;
@@ -20,6 +21,7 @@ import org.slf4j.Logger;
 import static dev.zanckor.advancedinventory.AdvancedInventory.LOGGER;
 import static dev.zanckor.advancedinventory.AdvancedInventory.MODID;
 import static net.minecraftforge.fml.config.ModConfig.Type.SERVER;
+import static net.minecraftforge.fml.config.ModConfig.Type.CLIENT;
 
 
 @Mod(MODID)
@@ -44,5 +46,6 @@ public class AdvancedInventory {
 
         LOGGER.info("Registering config for AdvancedInventory");
         ModLoadingContext.get().registerConfig(SERVER, ServerConfig.spec, "advancedinventory-server.toml");
+        ModLoadingContext.get().registerConfig(CLIENT, ClientConfig.spec, "advancedinventory-client.toml");
     }
 }

--- a/src/main/java/dev/zanckor/advancedinventory/core/config/ClientConfig.java
+++ b/src/main/java/dev/zanckor/advancedinventory/core/config/ClientConfig.java
@@ -1,0 +1,25 @@
+package dev.zanckor.advancedinventory.core.config;
+
+import net.minecraftforge.common.ForgeConfigSpec;
+
+public class ClientConfig {
+    private static final String CATEGORY_GENERAL = "general";
+    private static final String ENABLE_RENDER_COUNT_KEY = "enableItemRenderCount";
+
+    private static final ForgeConfigSpec.Builder builder = new ForgeConfigSpec.Builder();
+    public static final ForgeConfigSpec.BooleanValue ENABLE_RENDER_COUNT;
+
+    public static ForgeConfigSpec spec;
+
+    static {
+        builder.push("AdvancedInventory");
+        builder.comment("Client configuration").push(CATEGORY_GENERAL);
+
+        ENABLE_RENDER_COUNT = builder
+                .comment("Enable abbreviated item count rendering on items")
+                .define(ENABLE_RENDER_COUNT_KEY, true);
+
+        builder.pop();
+        spec = builder.build();
+    }
+}

--- a/src/main/java/dev/zanckor/advancedinventory/mixin/inventory/TextItemRendererMixin.java
+++ b/src/main/java/dev/zanckor/advancedinventory/mixin/inventory/TextItemRendererMixin.java
@@ -2,6 +2,7 @@ package dev.zanckor.advancedinventory.mixin.inventory;
 
 import com.mojang.blaze3d.vertex.PoseStack;
 import net.minecraft.client.gui.Font;
+import dev.zanckor.advancedinventory.core.config.ClientConfig;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
@@ -33,6 +34,8 @@ public abstract class TextItemRendererMixin {
 
     @Inject(method = "renderItemDecorations(Lnet/minecraft/client/gui/Font;Lnet/minecraft/world/item/ItemStack;IILjava/lang/String;)V", at = @At("HEAD"), cancellable = true)
     public void renderItemDecorations(Font font, ItemStack itemStack, int p_282641_, int p_282146_, @Nullable String s, CallbackInfo ci) {
+        if (!ClientConfig.ENABLE_RENDER_COUNT.get())
+            return;
         var value = itemStack.getCount();
 
         String formattedInt = value > 1 ? String.valueOf(value) : "";


### PR DESCRIPTION
## Summary
- allow turning item count abbreviations on/off with a new client config
- register the config at startup
- guard the item count mixin with the new option

## Testing
- `sh gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684efeb6a32083268f62fa25ebd84d00